### PR TITLE
bug(conf): Fix mod.ts main file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish package
+        run: npx jsr publish

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
     "name": "@ddspog/pom",
     "version": "1.0.0",
+    "license": "MIT",
     "exports":"./mod.ts",
     "nodeModulesDir": "auto",
     "tasks": {

--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,1 @@
-export * from '@src';
+export * from './src/mod.ts';


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for publishing, updates the package metadata in `deno.json`, and fixes an import path in `mod.ts`. Below are the key changes grouped by theme:

### CI/CD Workflow:
* Added a new GitHub Actions workflow (`.github/workflows/publish.yml`) to automate the publishing process. The workflow triggers on pushes to the `main` branch and uses `npx jsr publish` to publish the package.

### Package Metadata:
* Updated the `deno.json` file to include a `license` field with the value "MIT".

### Codebase Maintenance:
* Fixed the export path in `mod.ts` by changing it from `@src` to a relative path `./src/mod.ts` for better compatibility.